### PR TITLE
Fix critical underscore alerts

### DIFF
--- a/Presentations/Trends_in_Enterprise_WP_Content/TrendsinEnterpriseWPContent-revealJS/package.json
+++ b/Presentations/Trends_in_Enterprise_WP_Content/TrendsinEnterpriseWPContent-revealJS/package.json
@@ -21,7 +21,7 @@
     "node": "~0.8.0"
   },
   "dependencies": {
-    "underscore": "~1.5.1",
+    "underscore": "~1.12.1",
     "express": "~2.5.9",
     "mustache": "~0.7.2",
     "socket.io": "~0.9.13"

--- a/Presentations/VIP_Developer_Orientation/package.json
+++ b/Presentations/VIP_Developer_Orientation/package.json
@@ -21,7 +21,7 @@
     "node": "~0.8.0"
   },
   "dependencies": {
-    "underscore": "~1.5.1",
+    "underscore": "~1.12.1",
     "express": "~2.5.9",
     "mustache": "~0.7.2",
     "socket.io": "~0.9.13"

--- a/Training/Superuser_Training_Slides/package.json
+++ b/Training/Superuser_Training_Slides/package.json
@@ -21,7 +21,7 @@
     "node": "~0.8.0"
   },
   "dependencies": {
-    "underscore": "~1.5.1",
+    "underscore": "~1.12.1",
     "express": "~2.5.9",
     "mustache": "~0.7.2",
     "socket.io": "~0.9.13"


### PR DESCRIPTION
## Summary
- Updates the direct `underscore` dependency in the three reveal.js slide packages to the patched `~1.12.1` range.
- Leaves lockfiles uncommitted because this repository does not currently track npm lockfiles.

## Testing
- `jq empty` across all package manifests
- Temporary `npm install --package-lock-only --ignore-scripts` in each affected package confirmed `underscore@1.12.1` resolution
- `git diff --check`

Note: generating modern temporary lockfiles exposes the old reveal.js / Node 0.8-era dependency stack, including additional audit findings. This PR intentionally keeps the current manifest-only repository shape and targets the current GitHub critical alerts.