### PR TITLE
Fix high dependency alerts in slide packages

### DIFF
--- a/Presentations/Trends_in_Enterprise_WP_Content/TrendsinEnterpriseWPContent-revealJS/package.json
+++ b/Presentations/Trends_in_Enterprise_WP_Content/TrendsinEnterpriseWPContent-revealJS/package.json
@@ -21,9 +21,9 @@
     "node": "~0.8.0"
   },
   "dependencies": {
-    "underscore": "~1.12.1",
+    "underscore": "~1.13.8",
     "express": "~2.5.9",
-    "mustache": "~0.7.2",
+    "mustache": "~4.2.0",
     "socket.io": "~0.9.13"
   },
   "devDependencies": {
@@ -35,7 +35,7 @@
     "grunt-contrib-sass": "~0.5.0",
     "grunt-contrib-connect": "~0.4.1",
     "grunt-zip": "~0.7.0",
-    "grunt": "~0.4.0"
+    "grunt": "~1.6.2"
   },
   "licenses": [
     {

--- a/Presentations/VIP_Developer_Orientation/package.json
+++ b/Presentations/VIP_Developer_Orientation/package.json
@@ -21,9 +21,9 @@
     "node": "~0.8.0"
   },
   "dependencies": {
-    "underscore": "~1.12.1",
+    "underscore": "~1.13.8",
     "express": "~2.5.9",
-    "mustache": "~0.7.2",
+    "mustache": "~4.2.0",
     "socket.io": "~0.9.13"
   },
   "devDependencies": {
@@ -35,7 +35,7 @@
     "grunt-contrib-sass": "~0.5.0",
     "grunt-contrib-connect": "~0.4.1",
     "grunt-zip": "~0.7.0",
-    "grunt": "~0.4.0"
+    "grunt": "~1.6.2"
   },
   "licenses": [
     {

--- a/Training/Superuser_Training_Slides/package.json
+++ b/Training/Superuser_Training_Slides/package.json
@@ -21,9 +21,9 @@
     "node": "~0.8.0"
   },
   "dependencies": {
-    "underscore": "~1.12.1",
+    "underscore": "~1.13.8",
     "express": "~2.5.9",
-    "mustache": "~0.7.2",
+    "mustache": "~4.2.0",
     "socket.io": "~0.9.13"
   },
   "devDependencies": {
@@ -35,7 +35,7 @@
     "grunt-contrib-sass": "~0.5.0",
     "grunt-contrib-connect": "~0.4.1",
     "grunt-zip": "~0.7.0",
-    "grunt": "~0.4.0"
+    "grunt": "~1.6.2"
   },
   "licenses": [
     {


### PR DESCRIPTION
## Summary
- Updates `underscore`, `mustache`, and `grunt` in the three reveal.js slide package manifests.
- Keeps the change manifest-only because this repo does not currently include npm lockfiles for these packages.

## Validation
- `jq empty` on all three changed `package.json` files
- `npm install --package-lock-only --ignore-scripts --dry-run --audit=false --fund=false --engine-strict=false --legacy-peer-deps --prefix <slide package>` for each changed package
- `git diff --check`

Note: npm reports the existing `node: ~0.8.0` engine metadata as unsupported on the current local Node version. Dependency resolution still completed in dry-run mode.
